### PR TITLE
🧪 copy the test files to the output directory

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,3 +30,12 @@ add_test(NAME ${PROJECT_NAME}
   COMMAND ${PROJECT_NAME}-main
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.."
 )
+
+add_custom_command(TARGET ${PROJECT_NAME}-main POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E make_directory
+          "$<TARGET_FILE_DIR:${PROJECT_NAME}-main>/tests/jsons"
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+          "${CMAKE_CURRENT_SOURCE_DIR}/jsons"
+          "$<TARGET_FILE_DIR:${PROJECT_NAME}-main>/tests/jsons"
+  COMMENT "Copying test jsons to output directory"
+)


### PR DESCRIPTION
Fixes #12 
Let me know if this is the way you want to handle it, I could *try* to make it use the project root as the working directory, but I am unsure whether that's always enforced...
@karnkaul 